### PR TITLE
Implement rememberable session cookie

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -59,10 +59,6 @@
         {Credo.Check.Warning.IoInspect},
         {Credo.Check.Warning.LazyLogging},
         {Credo.Check.Warning.MapGetUnsafePass},
-        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
-        {Credo.Check.Warning.NameRedeclarationByCase, false},
-        {Credo.Check.Warning.NameRedeclarationByDef, false},
-        {Credo.Check.Warning.NameRedeclarationByFn, false},
         {Credo.Check.Warning.OperationOnSameValues},
         {Credo.Check.Warning.OperationWithConstantResult},
         {Credo.Check.Warning.RaiseInsideRescue},
@@ -73,7 +69,7 @@
         {Credo.Check.Warning.UnusedPathOperation},
         {Credo.Check.Warning.UnusedRegexOperation},
         {Credo.Check.Warning.UnusedStringOperation},
-        {Credo.Check.Warning.UnusedTupleOperation},
+        {Credo.Check.Warning.UnusedTupleOperation}
       ]
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- `PlugDeviseSession.Rememberable` module for handling Devise's remember session cookie.
+
 ## [0.3.0] - 2018-07-31
 ### Added
 - Function to delete user auth data (`PlugDeviseSession.Helpers.delete_user_auth_data/2`).

--- a/lib/plug_devise_session/rememberable.ex
+++ b/lib/plug_devise_session/rememberable.ex
@@ -1,0 +1,118 @@
+defmodule PlugDeviseSession.Rememberable do
+  @moduledoc """
+  Helps issuing and reading Devise's remember user cookie.
+
+  Important module assumptions:
+
+    * All `Plug.Conn` structures should have a valid `secret_key_base` set.
+    * User authorization info is a three element tuple of the form: `{id, auth_key, timestamp}`.
+    * Remember timestamps are required to be in the `Etc/UTC` time zone.
+
+  """
+
+  @type id :: integer
+  @type auth_key :: String.t()
+  @type timestamp :: DateTime.t()
+  @type scope :: atom | String.t()
+  @type user_auth_info :: {id, auth_key, timestamp}
+
+  @type opts :: [
+          key_digest: atom,
+          key_iterations: integer,
+          key_length: integer,
+          serializer: module,
+          signing_salt: binary
+        ]
+
+  alias Plug.Conn
+  alias Plug.Crypto.KeyGenerator
+  alias PlugRailsCookieSessionStore.MessageVerifier
+
+  @default_opts [
+    key_digest: :sha,
+    key_iterations: 1000,
+    key_length: 64,
+    serializer: ExMarshal,
+    signing_salt: "signed cookie"
+  ]
+
+  @doc """
+  Sets a signed remember user cookie on the connection.
+
+  ## Options
+
+    * `:key_digest` - digest algorithm to use for deriving the signing key. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to `:sha`.
+    * `:key_iterations` - number of iterations for signing key derivation. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to 1000.
+    * `:key_length` - desired length of derived signing key. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to 64.
+    * `:serializer` - module used for cookie data serialization, defaults to `PlugDeviseSession.Marshal` which in turn uses `ExMarshal` (a Rails-compatible marshal module).
+    * `:signing_salt` - salt used for signing key derivation. Should be set to the value used by Rails, defaults to "signed cookie".
+
+  """
+  @spec remember_user(Plug.Conn.t(), user_auth_info, scope, opts) :: Plug.Conn.t()
+  def remember_user(conn, {id, auth_key, timestamp}, scope \\ :user, opts \\ []) do
+    options = Keyword.merge(@default_opts, opts)
+    serializer = Keyword.fetch!(options, :serializer)
+    signing_key = generate_key(conn, options)
+
+    cookie_value =
+      [[id], auth_key, encode_timestamp(timestamp)]
+      |> serializer.encode()
+      |> MessageVerifier.sign(signing_key)
+      |> URI.encode_www_form()
+
+    Conn.put_resp_cookie(conn, "remember_#{scope}_token", cookie_value)
+  end
+
+  defp encode_timestamp(%DateTime{time_zone: "Etc/UTC", utc_offset: 0} = timestamp) do
+    microseconds = DateTime.to_unix(timestamp, :microseconds)
+    Float.to_string(microseconds / 1_000_000.0)
+  end
+
+  @doc """
+  Recovers user authentication info from remember cookie.
+
+  ## Options
+
+  * `:key_digest` - digest algorithm to use for deriving the signing key. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to `:sha`.
+  * `:key_iterations` - number of iterations for signing key derivation. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to 1000.
+  * `:key_length` - desired length of derived signing key. Accepts any value supported by `Plug.Crypto.KeyGenerator.generate/3`, defaults to 64.
+  * `:serializer` - module used for cookie data serialization, defaults to `PlugDeviseSession.Marshal` which in turn uses `ExMarshal` (a Rails-compatible marshal module).
+  * `:signing_salt` - salt used for signing key derivation. Should be set to the value used by Rails, defaults to "signed cookie".
+
+  """
+  @spec recover_user(Plug.Conn.t(), scope, opts) :: {:ok, user_auth_info} | {:error, :unauthorized}
+  def recover_user(conn, scope \\ :user, opts \\ []) do
+    options = Keyword.merge(@default_opts, opts)
+    serializer = Keyword.fetch!(options, :serializer)
+    verification_key = generate_key(conn, options)
+
+    with cookie_value when is_binary(cookie_value) <- conn.cookies["remember_#{scope}_token"],
+         decoded_cookie_value <- URI.decode_www_form(cookie_value),
+         {:ok, contents} <- MessageVerifier.verify(decoded_cookie_value, verification_key) do
+      [[id], auth_key, timestamp] = serializer.decode(contents)
+      {:ok, {id, auth_key, decode_timestamp(timestamp)}}
+    else
+      _ -> {:error, :unauthorized}
+    end
+  end
+
+  defp decode_timestamp(timestamp) when is_binary(timestamp) do
+    {seconds, ""} = Float.parse(timestamp)
+
+    (seconds * 1_000_000)
+    |> trunc()
+    |> DateTime.from_unix!(:microseconds)
+  end
+
+  defp generate_key(%Plug.Conn{secret_key_base: secret_key_base}, opts) do
+    signing_salt = Keyword.fetch!(opts, :signing_salt)
+
+    key_options = [
+      digest: Keyword.fetch!(opts, :key_digest),
+      iterations: Keyword.fetch!(opts, :key_iterations),
+      length: Keyword.fetch!(opts, :key_length)
+    ]
+
+    KeyGenerator.generate(secret_key_base, signing_salt, key_options)
+  end
+end

--- a/test/plug_devise_session/rememberable_test.exs
+++ b/test/plug_devise_session/rememberable_test.exs
@@ -1,0 +1,123 @@
+defmodule PlugDeviseSession.RememberableTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  use Plug.Test
+  alias PlugDeviseSession.Rememberable
+
+  @secret_key_base "this is a super secret key"
+  @user_id 5
+  @user_auth_key "beginning of encrypted password"
+  @user_timestamp %DateTime{
+    year: 2018,
+    month: 8,
+    day: 3,
+    hour: 11,
+    minute: 22,
+    second: 33,
+    microsecond: {0, 0},
+    utc_offset: 0,
+    std_offset: 0,
+    zone_abbr: "UTC",
+    time_zone: "Etc/UTC"
+  }
+  @user_auth_data {@user_id, @user_auth_key, @user_timestamp}
+  @reference_cookie_content "BAhbCFsGaQpJIiRiZWdpbm5pbmcgb2YgZW5jcnlwdGVkIHBhc3N3b3JkBjoGRVRJIhExNTMzMjk1MzUzLjAGOwBU"
+
+  def patch_secret_key_base(conn, secret_key_base) do
+    put_in(conn.secret_key_base, secret_key_base)
+  end
+
+  setup do
+    conn = :post |> conn("/sign-in") |> patch_secret_key_base(@secret_key_base)
+    {:ok, conn: conn}
+  end
+
+  describe "remember_user/4" do
+    test "issues remember user cookie", %{conn: conn} do
+      remember_conn =
+        conn
+        |> Rememberable.remember_user(@user_auth_data)
+        |> fetch_cookies()
+
+      cookie_value = remember_conn.cookies["remember_user_token"]
+      [content, _digest] = String.split(cookie_value, "--")
+
+      assert is_binary(cookie_value)
+      assert content == @reference_cookie_content
+    end
+
+    test "respects scope parameter", %{conn: conn} do
+      remember_conn =
+        conn
+        |> Rememberable.remember_user(@user_auth_data, :employee)
+        |> fetch_cookies()
+
+      assert is_binary(remember_conn.cookies["remember_employee_token"])
+    end
+
+    test "raises when timestamp is not in UTC", %{conn: conn} do
+      cest_timestamp = %DateTime{
+        @user_timestamp
+        | time_zone: "Europe/Warsaw",
+          utc_offset: 7_200,
+          zone_abbr: "CEST"
+      }
+
+      assert_raise(FunctionClauseError, fn ->
+        Rememberable.remember_user(conn, {@user_id, @user_auth_key, cest_timestamp})
+      end)
+    end
+  end
+
+  describe "recover_user/3" do
+    test "recovers user auth data", %{conn: conn} do
+      {:ok, {user_id, user_auth_key, user_timestamp}} =
+        conn
+        |> Rememberable.remember_user(@user_auth_data)
+        |> fetch_cookies()
+        |> Rememberable.recover_user()
+
+      assert user_id == @user_id
+      assert user_auth_key == @user_auth_key
+      assert DateTime.compare(user_timestamp, @user_timestamp) == :eq
+    end
+
+    test "respects scope parameter", %{conn: conn} do
+      {:ok, {user_id, user_auth_key, user_timestamp}} =
+        conn
+        |> Rememberable.remember_user(@user_auth_data, :employee)
+        |> fetch_cookies()
+        |> Rememberable.recover_user(:employee)
+
+      assert user_id == @user_id
+      assert user_auth_key == @user_auth_key
+      assert DateTime.compare(user_timestamp, @user_timestamp) == :eq
+    end
+
+    test "returns unauthorized error when cookie not set", %{conn: conn} do
+      assert {:error, :unauthorized} =
+               conn
+               |> fetch_cookies()
+               |> Rememberable.recover_user()
+    end
+
+    test "returns unauthorized error when cookie signed with different secret", %{conn: conn} do
+      assert {:error, :unauthorized} =
+               conn
+               |> patch_secret_key_base("some secret key base")
+               |> Rememberable.remember_user(@user_auth_data)
+               |> fetch_cookies()
+               |> patch_secret_key_base("other secret key base")
+               |> Rememberable.recover_user()
+    end
+
+    test "returns unauthorized error when cookie signed with different salt", %{conn: conn} do
+      assert {:error, :unauthorized} =
+               conn
+               |> Rememberable.remember_user(@user_auth_data, :user, signing_salt: "some salt")
+               |> fetch_cookies()
+               |> Rememberable.recover_user(:user, signing_salt: "other salt")
+    end
+  end
+end


### PR DESCRIPTION
This implements a module for handling Devise's rememberable session cookie. The module contains two methods:

* `remember_user/4` for persisting user auth information in a remember cookie
* `recover_user/3` for recovering user auth information from the remember cookie