### PR TITLE
Add domain and max_age options to remember_user/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- Allow to pass `domain` and `max_age` options to `PlugDeviseSession.Rememberable.remember_user/4`.
+
 ## [0.4.0] - 2018-08-03
 ### Added
 - `PlugDeviseSession.Rememberable` module for handling Devise's remember session cookie.

--- a/lib/plug_devise_session/rememberable.ex
+++ b/lib/plug_devise_session/rememberable.ex
@@ -106,8 +106,9 @@ defmodule PlugDeviseSession.Rememberable do
 
   defp decode_timestamp(timestamp) when is_binary(timestamp) do
     {seconds, ""} = Float.parse(timestamp)
+    miliseconds = seconds * 1_000_000
 
-    (seconds * 1_000_000)
+    miliseconds
     |> trunc()
     |> DateTime.from_unix!(:microseconds)
   end

--- a/test/plug_devise_session/rememberable_test.exs
+++ b/test/plug_devise_session/rememberable_test.exs
@@ -56,6 +56,28 @@ defmodule PlugDeviseSession.RememberableTest do
       assert is_binary(remember_conn.cookies["remember_employee_token"])
     end
 
+    test "respects domain option", %{conn: conn} do
+      remember_conn =
+        Rememberable.remember_user(conn, @user_auth_data, :user, domain: ".example.com")
+
+      remember_cookie = remember_conn.resp_cookies["remember_user_token"]
+      assert remember_cookie.domain == ".example.com"
+    end
+
+    test "respects max_age option", %{conn: conn} do
+      remember_conn = Rememberable.remember_user(conn, @user_auth_data, :user, max_age: 12_345)
+
+      remember_cookie = remember_conn.resp_cookies["remember_user_token"]
+      assert remember_cookie.max_age == 12_345
+    end
+
+    test "issues a http_only cookie", %{conn: conn} do
+      remember_conn = Rememberable.remember_user(conn, @user_auth_data)
+
+      remember_cookie = remember_conn.resp_cookies["remember_user_token"]
+      assert remember_cookie.http_only
+    end
+
     test "raises when timestamp is not in UTC", %{conn: conn} do
       cest_timestamp = %DateTime{
         @user_timestamp

--- a/test/plug_devise_session/rememberable_test.exs
+++ b/test/plug_devise_session/rememberable_test.exs
@@ -71,6 +71,13 @@ defmodule PlugDeviseSession.RememberableTest do
       assert remember_cookie.max_age == 12_345
     end
 
+    test "defaults max_age to 2 weeks", %{conn: conn} do
+      remember_conn = Rememberable.remember_user(conn, @user_auth_data)
+      remember_cookie = remember_conn.resp_cookies["remember_user_token"]
+      two_weeks_in_seconds = 2 * 7 * 24 * 60 * 60
+      assert remember_cookie.max_age == two_weeks_in_seconds
+    end
+
     test "issues a http_only cookie", %{conn: conn} do
       remember_conn = Rememberable.remember_user(conn, @user_auth_data)
 


### PR DESCRIPTION
* Adds `domain` and `max_age` options to `PlugDeviseSession.Rememberable.remember_user/4` so the remember user cookie can be customized.
* Sets the default cookie expiry and max age to 2 weeks.