### PR TITLE
Add ability to configure cookie key using env variable

### DIFF
--- a/lib/plug_devise_session.ex
+++ b/lib/plug_devise_session.ex
@@ -74,6 +74,7 @@ defmodule PlugDeviseSession do
   defp patch_config(config) do
     config
     |> update_in([:cookie_opts, :domain], &Confix.parse/1)
+    |> update_in([:key], &Confix.parse/1)
     |> update_in([:store_config, :encryption_salt], &Confix.parse/1)
     |> update_in([:store_config, :signing_salt], &Confix.parse/1)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PlugDeviseSession.Mixfile do
   def project do
     [
       app: :plug_devise_session,
-      version: "0.6.0",
+      version: "0.7.0",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Some parts of the plug configuration can be configured using `{:system, "ENV_VARIABLE_NAME"}` tuple, but cookie key was not one of them. This PR changes that.